### PR TITLE
fix: skip collector if pg<17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ workflows:
             - cimg/postgres:14.9
             - cimg/postgres:15.4
             - cimg/postgres:16.0
+            - cimg/postgres:17.0
     - prometheus/build:
         name: build
         parallelism: 3

--- a/collector/pg_stat_checkpointer.go
+++ b/collector/pg_stat_checkpointer.go
@@ -1,0 +1,221 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const statCheckpointerSubsystem = "stat_checkpointer"
+
+func init() {
+	// WARNING:
+	//   Disabled by default because this set of metrics is only available from Postgres 17
+	registerCollector(statCheckpointerSubsystem, defaultDisabled, NewPGStatCheckpointerCollector)
+}
+
+type PGStatCheckpointerCollector struct {
+}
+
+func NewPGStatCheckpointerCollector(collectorConfig) (Collector, error) {
+	return &PGStatCheckpointerCollector{}, nil
+}
+
+var (
+	statCheckpointerNumTimedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "num_timed_total"),
+		"Number of scheduled checkpoints due to timeout",
+		[]string{},
+		prometheus.Labels{},
+	)
+	statCheckpointerNumRequestedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "num_requested_total"),
+		"Number of requested checkpoints that have been performed",
+		[]string{},
+		prometheus.Labels{},
+	)
+	statCheckpointerRestartpointsTimedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "restartpoints_timed_total"),
+		"Number of scheduled restartpoints due to timeout or after a failed attempt to perform it",
+		[]string{},
+		prometheus.Labels{},
+	)
+	statCheckpointerRestartpointsReqDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "restartpoints_req_total"),
+		"Number of requested restartpoints",
+		[]string{},
+		prometheus.Labels{},
+	)
+	statCheckpointerRestartpointsDoneDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "restartpoints_done_total"),
+		"Number of restartpoints that have been performed",
+		[]string{},
+		prometheus.Labels{},
+	)
+	statCheckpointerWriteTimeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "write_time_total"),
+		"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are written to disk, in milliseconds",
+		[]string{},
+		prometheus.Labels{},
+	)
+	statCheckpointerSyncTimeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "sync_time_total"),
+		"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are synchronized to disk, in milliseconds",
+		[]string{},
+		prometheus.Labels{},
+	)
+	statCheckpointerBuffersWrittenDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "buffers_written_total"),
+		"Number of buffers written during checkpoints and restartpoints",
+		[]string{},
+		prometheus.Labels{},
+	)
+	statCheckpointerStatsResetDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, statCheckpointerSubsystem, "stats_reset_total"),
+		"Time at which these statistics were last reset",
+		[]string{},
+		prometheus.Labels{},
+	)
+
+	statCheckpointerQuery = `SELECT
+		num_timed
+		,num_requested
+		,restartpoints_timed
+		,restartpoints_req
+		,restartpoints_done
+		,write_time
+		,sync_time
+		,buffers_written
+		,stats_reset
+	FROM pg_stat_checkpointer;`
+)
+
+func (PGStatCheckpointerCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+	db := instance.getDB()
+	row := db.QueryRowContext(ctx, statCheckpointerQuery)
+
+	// num_timed           = nt  = bigint
+	// num_requested       = nr  = bigint
+	// restartpoints_timed = rpt = bigint
+	// restartpoints_req   = rpr = bigint
+	// restartpoints_done  = rpd = bigint
+	// write_time          = wt  = double precision
+	// sync_time           = st  = double precision
+	// buffers_written     = bw  = bigint
+	// stats_reset         = sr  = timestamp
+
+	var nt, nr, rpt, rpr, rpd, bw sql.NullInt64
+	var wt, st sql.NullFloat64
+	var sr sql.NullTime
+
+	err := row.Scan(&nt, &nr, &rpt, &rpr, &rpd, &wt, &st, &bw, &sr)
+	if err != nil {
+		return err
+	}
+
+	ntMetric := 0.0
+	if nt.Valid {
+		ntMetric = float64(nt.Int64)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerNumTimedDesc,
+		prometheus.CounterValue,
+		ntMetric,
+	)
+
+	nrMetric := 0.0
+	if nr.Valid {
+		nrMetric = float64(nr.Int64)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerNumRequestedDesc,
+		prometheus.CounterValue,
+		nrMetric,
+	)
+
+	rptMetric := 0.0
+	if rpt.Valid {
+		rptMetric = float64(rpt.Int64)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerRestartpointsTimedDesc,
+		prometheus.CounterValue,
+		rptMetric,
+	)
+
+	rprMetric := 0.0
+	if rpr.Valid {
+		rprMetric = float64(rpr.Int64)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerRestartpointsReqDesc,
+		prometheus.CounterValue,
+		rprMetric,
+	)
+
+	rpdMetric := 0.0
+	if rpd.Valid {
+		rpdMetric = float64(rpd.Int64)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerRestartpointsDoneDesc,
+		prometheus.CounterValue,
+		rpdMetric,
+	)
+
+	wtMetric := 0.0
+	if wt.Valid {
+		wtMetric = float64(wt.Float64)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerWriteTimeDesc,
+		prometheus.CounterValue,
+		wtMetric,
+	)
+
+	stMetric := 0.0
+	if st.Valid {
+		stMetric = float64(st.Float64)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerSyncTimeDesc,
+		prometheus.CounterValue,
+		stMetric,
+	)
+
+	bwMetric := 0.0
+	if bw.Valid {
+		bwMetric = float64(bw.Int64)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerBuffersWrittenDesc,
+		prometheus.CounterValue,
+		bwMetric,
+	)
+
+	srMetric := 0.0
+	if sr.Valid {
+		srMetric = float64(sr.Time.Unix())
+	}
+	ch <- prometheus.MustNewConstMetric(
+		statCheckpointerStatsResetDesc,
+		prometheus.CounterValue,
+		srMetric,
+	)
+
+	return nil
+}

--- a/collector/pg_stat_checkpointer.go
+++ b/collector/pg_stat_checkpointer.go
@@ -16,7 +16,9 @@ package collector
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -29,10 +31,11 @@ func init() {
 }
 
 type PGStatCheckpointerCollector struct {
+	log *slog.Logger
 }
 
-func NewPGStatCheckpointerCollector(collectorConfig) (Collector, error) {
-	return &PGStatCheckpointerCollector{}, nil
+func NewPGStatCheckpointerCollector(config collectorConfig) (Collector, error) {
+	return &PGStatCheckpointerCollector{log: config.logger}, nil
 }
 
 var (
@@ -104,8 +107,15 @@ var (
 	FROM pg_stat_checkpointer;`
 )
 
-func (PGStatCheckpointerCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGStatCheckpointerCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
+
+	before17 := instance.version.Compare(semver.MustParse("17.0.0"))
+	if before17 < 0 {
+		c.log.Warn("pg_stat_checkpointer collector is not available on PostgreSQL < 17.0.0, skipping")
+		return nil
+	}
+
 	row := db.QueryRowContext(ctx, statCheckpointerQuery)
 
 	// num_timed           = nt  = bigint

--- a/collector/pg_stat_checkpointer_test.go
+++ b/collector/pg_stat_checkpointer_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 )
 
-func TestPGStatBGWriterCollector(t *testing.T) {
+func TestPGStatCheckpointerCollector(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("Error opening a stub db connection: %s", err)
@@ -33,16 +33,14 @@ func TestPGStatBGWriterCollector(t *testing.T) {
 	inst := &instance{db: db}
 
 	columns := []string{
-		"checkpoints_timed",
-		"checkpoints_req",
-		"checkpoint_write_time",
-		"checkpoint_sync_time",
-		"buffers_checkpoint",
-		"buffers_clean",
-		"maxwritten_clean",
-		"buffers_backend",
-		"buffers_backend_fsync",
-		"buffers_alloc",
+		"num_timed",
+		"num_requested",
+		"restartpoints_timed",
+		"restartpoints_req",
+		"restartpoints_done",
+		"write_time",
+		"sync_time",
+		"buffers_written",
 		"stats_reset"}
 
 	srT, err := time.Parse("2006-01-02 15:04:05.00000-07", "2023-05-25 17:10:42.81132-07")
@@ -51,16 +49,16 @@ func TestPGStatBGWriterCollector(t *testing.T) {
 	}
 
 	rows := sqlmock.NewRows(columns).
-		AddRow(354, 4945, 289097744, 1242257, int64(3275602074), 89320867, 450139, 2034563757, 0, int64(2725688749), srT)
-	mock.ExpectQuery(sanitizeQuery(statBGWriterQueryBefore17)).WillReturnRows(rows)
+		AddRow(354, 4945, 289097744, 1242257, int64(3275602074), 89320867, 450139, 2034563757, srT)
+	mock.ExpectQuery(sanitizeQuery(statCheckpointerQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
-		c := PGStatBGWriterCollector{}
+		c := PGStatCheckpointerCollector{}
 
 		if err := c.Update(context.Background(), inst, ch); err != nil {
-			t.Errorf("Error calling PGStatBGWriterCollector.Update: %s", err)
+			t.Errorf("Error calling PGStatCheckpointerCollector.Update: %s", err)
 		}
 	}()
 
@@ -73,8 +71,6 @@ func TestPGStatBGWriterCollector(t *testing.T) {
 		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 89320867},
 		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 450139},
 		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 2034563757},
-		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 0},
-		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 2725688749},
 		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 1685059842},
 	}
 
@@ -89,7 +85,7 @@ func TestPGStatBGWriterCollector(t *testing.T) {
 	}
 }
 
-func TestPGStatBGWriterCollectorNullValues(t *testing.T) {
+func TestPGStatCheckpointerCollectorNullValues(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("Error opening a stub db connection: %s", err)
@@ -99,35 +95,31 @@ func TestPGStatBGWriterCollectorNullValues(t *testing.T) {
 	inst := &instance{db: db}
 
 	columns := []string{
-		"checkpoints_timed",
-		"checkpoints_req",
-		"checkpoint_write_time",
-		"checkpoint_sync_time",
-		"buffers_checkpoint",
-		"buffers_clean",
-		"maxwritten_clean",
-		"buffers_backend",
-		"buffers_backend_fsync",
-		"buffers_alloc",
+		"num_timed",
+		"num_requested",
+		"restartpoints_timed",
+		"restartpoints_req",
+		"restartpoints_done",
+		"write_time",
+		"sync_time",
+		"buffers_written",
 		"stats_reset"}
 
 	rows := sqlmock.NewRows(columns).
-		AddRow(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-	mock.ExpectQuery(sanitizeQuery(statBGWriterQueryBefore17)).WillReturnRows(rows)
+		AddRow(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	mock.ExpectQuery(sanitizeQuery(statCheckpointerQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
-		c := PGStatBGWriterCollector{}
+		c := PGStatCheckpointerCollector{}
 
 		if err := c.Update(context.Background(), inst, ch); err != nil {
-			t.Errorf("Error calling PGStatBGWriterCollector.Update: %s", err)
+			t.Errorf("Error calling PGStatCheckpointerCollector.Update: %s", err)
 		}
 	}()
 
 	expected := []MetricResult{
-		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 0},
-		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 0},
 		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 0},
 		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 0},
 		{labels: labelMap{}, metricType: dto.MetricType_COUNTER, value: 0},


### PR DESCRIPTION
Hello,
Here a fix for https://github.com/prometheus-community/postgres_exporter/pull/1072#issuecomment-2503906073 where the collector fails on pg<17 when we use the exporter with the multi-target pattern